### PR TITLE
Fix xpack.security.http.ssl.enabled setting

### DIFF
--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -116,4 +116,6 @@ xpack.security.transport.ssl.enabled: false
 {% if elasticsearch_https_enabled %}
 xpack.security.http.ssl.enabled: true
 xpack.security.http.ssl.keystore.path: {{ elasticsearch_certs_dir }}/http.p12
+{% else %}
+xpack.security.http.ssl.enabled: false
 {% endif %}


### PR DESCRIPTION
If elasticsearch_https_enabled is set to false, set xpack.security.http.ssl.enabled to false