### PR TITLE
fix: deprecated ipaddr filter

### DIFF
--- a/roles/elasticsearch/tasks/install_elasticsearch.yml
+++ b/roles/elasticsearch/tasks/install_elasticsearch.yml
@@ -136,12 +136,12 @@
 
 - set_fact:
     elastic_ip_address: "{{ item }}"
-  when: "item | ipaddr( elasticsearch_subnet )"
+  when: "item | ansible.utils.ipaddr( elasticsearch_subnet )"
   with_items: "{{ ansible_all_ipv4_addresses }}"
 
 - set_fact:
     elastic_iface: "{{ hostvars[inventory_hostname]['ansible_' + item ]['device'] }}"
-  when: "hostvars[inventory_hostname]['ansible_' + item ].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item ]['ipv4']['address'] | ipaddr( elasticsearch_subnet )"
+  when: "hostvars[inventory_hostname]['ansible_' + item ].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item ]['ipv4']['address'] | ansible.utils.ipaddr( elasticsearch_subnet )"
   with_items: "{{ ansible_interfaces }}"
 
 - name: Render elasticsearch configuration file

--- a/roles/elasticsearch/tasks/preflight.yml
+++ b/roles/elasticsearch/tasks/preflight.yml
@@ -46,10 +46,10 @@
 
 - set_fact:
     elastic_ip_address: "{{ item }}"
-  when: "item | ipaddr( elasticsearch_subnet )"
+  when: "item | ansible.utils.ipaddr( elasticsearch_subnet )"
   with_items: "{{ ansible_all_ipv4_addresses }}"
 
 - set_fact:
     elastic_iface: "{{ hostvars[inventory_hostname]['ansible_' + item ]['device'] }}"
-  when: "hostvars[inventory_hostname]['ansible_' + item ].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item ]['ipv4']['address'] | ipaddr( elasticsearch_subnet )"
+  when: "hostvars[inventory_hostname]['ansible_' + item ].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item ]['ipv4']['address'] | ansible.utils.ipaddr( elasticsearch_subnet )"
   with_items: "{{ ansible_interfaces }}"


### PR DESCRIPTION
Use the full ansible plugin FQN because the old syntax is deprecated and won't work anymore from 2024-01-01.