### PR TITLE
fix: wrong groups used in systemd service files

### DIFF
--- a/roles/elasticsearch/templates/elasticsearch.service.j2
+++ b/roles/elasticsearch/templates/elasticsearch.service.j2
@@ -11,7 +11,7 @@ EnvironmentFile=-{{ elasticsearch_env_file[ansible_os_family] }}
 WorkingDirectory={{ elasticsearch_extract_dir }}/elasticsearch
 
 User={{ elasticsearch_user }}
-Group={{ elasticsearch_user }}
+Group={{ elasticsearch_group }}
 
 ExecStart={{ elasticsearch_extract_dir }}/elasticsearch/bin/elasticsearch -p ${PID_DIR}/elasticsearch.pid --quiet
 

--- a/roles/logstash/templates/logstash.service.j2
+++ b/roles/logstash/templates/logstash.service.j2
@@ -11,7 +11,7 @@ EnvironmentFile=-{{ logstash_env_file[ansible_os_family] }}
 WorkingDirectory={{ logstash_extract_dir }}/logstash
 
 User={{ logstash_user }}
-Group={{ logstash_user }}
+Group={{ logstash_group }}
 
 ExecStart={{ logstash_extract_dir }}/logstash/bin/logstash -f {{ logstash_conf_dir }}/logstash.conf
 


### PR DESCRIPTION
this PR fix a bug where you pass an elasticsearch group and logstash group that are not used in systemd services templates